### PR TITLE
Add a key-binding to allow finding assignments in qf

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Biggest advantage of using this plugin is, it prevents the
 quickfix to jump to first result automatically. Thus preventing it to spoil
 your open buffer list.
 
-* Quickly search for symbol, function name, file name under the cursor
+* Quickly search for symbol, function name, file name, assignments under the cursor
 * Quickly search for visually selected text
 * Search results are shown in quickfix window, which is way more flexible for
   navigation compared to Cscope's fixed list
@@ -50,6 +50,7 @@ installed with a variety of plugin managers:
 <leader>t : Search for text matching word under the cursor/visualy selected text
 <leader>e : Enter an egrep patter for searching
 <leader>d : Search all the functions called by funtion name under the cursor
+<leader>a : Search all the places where the symbol under the cursor is assigned a value
 ```
 
 P.S.: `\` is the leader key by default. So the mappings are `\s`, `\g`, `\c`, etc. unless `<leader>` key is mapped to something else.
@@ -77,6 +78,7 @@ Use following `<plug>`s to your own liking:
 <plug>(quickr_cscope_text)
 <plug>(quickr_cscope_egrep)
 <plug>(quickr_cscope_functions)
+<plug>(quickr_cscope_assignments)
 ```
 
 There are 2 more additional `<plug>`s available for global defintion to open the result in

--- a/plugin/quickr-cscope.vim
+++ b/plugin/quickr-cscope.vim
@@ -166,6 +166,7 @@ nnoremap <silent> <plug>(quickr_cscope_includes)        :call <SID>quickr_cscope
 nnoremap <silent> <plug>(quickr_cscope_text)            :call <SID>quickr_cscope(expand("<cword>"), "t", "", "cs")<CR>
 nnoremap <silent> <plug>(quickr_cscope_functions)       :call <SID>quickr_cscope(expand("<cword>"), "d", "", "cs")<CR>
 nnoremap <silent> <plug>(quickr_cscope_egrep)           :call <SID>quickr_cscope(input('Enter egrep pattern: '), "e", "", "cs")<CR>
+nnoremap <silent> <plug>(quickr_cscope_assignments)     :call <SID>quickr_cscope(expand("<cword>"), "a", "", "cs")<CR>
 
 vnoremap <silent> <plug>(quickr_cscope_symbols)         :call <SID>quickr_cscope(<SID>get_visual_selection(), "s", "", "cs")<CR>
 vnoremap <silent> <plug>(quickr_cscope_callers)         :call <SID>quickr_cscope(<SID>get_visual_selection(), "c", "", "cs")<CR>
@@ -174,6 +175,7 @@ vnoremap <silent> <plug>(quickr_cscope_includes)        :call <SID>quickr_cscope
 vnoremap <silent> <plug>(quickr_cscope_text)            :call <SID>quickr_cscope(<SID>get_visual_selection(), "t", "", "cs")<CR>
 vnoremap <silent> <plug>(quickr_cscope_functions)       :call <SID>quickr_cscope(<SID>get_visual_selection(), "d", "", "cs")<CR>
 vnoremap <silent> <plug>(quickr_cscope_egrep)           :call <SID>quickr_cscope(<SID>get_visual_selection(), "e", "", "cs")<CR>
+vnoremap <silent> <plug>(quickr_cscope_assignments)     :call <SID>quickr_cscope(<SID>get_visual_selection(), "a", "", "cs")<CR>
 " }}
 
 if g:quickr_cscope_keymaps
@@ -185,6 +187,7 @@ if g:quickr_cscope_keymaps
     nmap <leader>t <plug>(quickr_cscope_text)
     nmap <leader>d <plug>(quickr_cscope_functions)
     nmap <leader>e <plug>(quickr_cscope_egrep)
+    nmap <leader>e <plug>(quickr_cscope_assignments)
 
     vmap <leader>g <plug>(quickr_cscope_global)
     vmap <leader>s <plug>(quickr_cscope_symbols)
@@ -194,14 +197,15 @@ if g:quickr_cscope_keymaps
     vmap <leader>t <plug>(quickr_cscope_text)
     vmap <leader>d <plug>(quickr_cscope_functions)
     vmap <leader>e <plug>(quickr_cscope_egrep)
+    vmap <leader>e <plug>(quickr_cscope_assignments)
 endif
 
 " Use quickfix window for cscope results. Clear previous results before the search.
 if empty(&cscopequickfix)
     if g:quickr_cscope_use_qf_g
-        set cscopequickfix=g-,s-,c-,f-,i-,t-,d-,e-
+        set cscopequickfix=g-,s-,c-,f-,i-,t-,d-,e-,a-
     else
-        set cscopequickfix=s-,c-,f-,i-,t-,d-,e-
+        set cscopequickfix=s-,c-,f-,i-,t-,d-,e-,a-
     endif
 endif
 


### PR DESCRIPTION
cscope provides a query called 'cs find a <str>' to
find all the assigments for the a varaible. This
commit adds the capability of writing such results
to the quickfix window with a key-binding.