### PR TITLE
Add git top-level path when adding cscope

### DIFF
--- a/plugin/quickr-cscope.vim
+++ b/plugin/quickr-cscope.vim
@@ -58,7 +58,8 @@ function! s:autoload_db()
         call s:debug_echo('Database file found at: ' . db)
         let &csprg=g:quickr_cscope_program
         call s:debug_echo('Trying to add the database file for program: ' . g:quickr_cscope_program)
-        silent! execute "cs add " . db
+        let root_path = trim(system("git rev-parse --show-toplevel"))
+        execute "cs add " . db  . " " . root_path
         return 1
     else
         call s:debug_echo('Database file not found.')


### PR DESCRIPTION
Hello, just made a small change to quickr-cscope.vim.
Pick this if you think it is needed.

I was using it to traverse the linux sources,
but it was difficult to go to function definitions when I was in subdirectories (like drivers/net/....)

Because the file path of function definition is relative, I was not able to open it in subdirectories.
So converted it to absolute path using the git root repository.
(Maybe there's better way because there will be a  repository that does not use git)